### PR TITLE
fix topojson type error; format new code

### DIFF
--- a/examples/mosaic-integration/package-lock.json
+++ b/examples/mosaic-integration/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
+        "@types/topojson-client": "^3.1.4",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "@vitejs/plugin-react": "^4.2.0",
@@ -1214,6 +1215,12 @@
       "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.3.tgz",
       "integrity": "sha512-kwJQsAROanCiMXSLjcTLmYVBIJ9Qyuqs92SaDIcj2EII2KnDgZbiU7it1Z/JfZd1gmxw/lAahMysQ6ZM+j3Ryw=="
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.13",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
+      "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1267,6 +1274,25 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.4.tgz",
+      "integrity": "sha512-Ntf3ZSetMYy7z3PrVCvcqmdRoVhgKA9UKN0ZuuZf8Ts2kcyL4qK34IXBs6qO5fem62EK4k03PtkJPVoroVu4/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.13.1",

--- a/examples/mosaic-integration/package.json
+++ b/examples/mosaic-integration/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
+    "@types/topojson-client": "^3.1.4",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/examples/mosaic-integration/src/vizzes/GaiaStarCatalogViz.ts
+++ b/examples/mosaic-integration/src/vizzes/GaiaStarCatalogViz.ts
@@ -34,19 +34,23 @@ export class GaiaStarCatalogViz implements Viz {
     const $brush = vg.Selection.crossfilter();
     const $bandwidth = vg.Param.value(0);
     const $binWidth = vg.Param.value(2);
-    const $scaleType = vg.Param.value("sqrt");
+    const $scaleType = vg.Param.value('sqrt');
 
     return vg.hconcat(
       vg.vconcat(
         vg.plot(
-          vg.raster(
-            vg.from("gaia_viz", { filterBy: $brush }),
-            { x: "u", y: "v", fill: "density", bandwidth: $bandwidth, binWidth: $binWidth, binType: "normal" }
-          ),
+          vg.raster(vg.from('gaia_viz', { filterBy: $brush }), {
+            x: 'u',
+            y: 'v',
+            fill: 'density',
+            bandwidth: $bandwidth,
+            binWidth: $binWidth,
+            binType: 'normal',
+          }),
           vg.intervalXY({ pixelSize: 2, as: $brush }),
           vg.xyDomain(vg.Fixed),
           vg.colorScale($scaleType),
-          vg.colorScheme("viridis"),
+          vg.colorScheme('viridis'),
           vg.width(440),
           vg.height(250),
           vg.marginLeft(25),
@@ -55,10 +59,12 @@ export class GaiaStarCatalogViz implements Viz {
         ),
         vg.hconcat(
           vg.plot(
-            vg.rectY(
-              vg.from("gaia_viz", { filterBy: $brush }),
-              { x: vg.bin("phot_g_mean_mag"), y: vg.count(), fill: "steelblue", inset: 0.5 }
-            ),
+            vg.rectY(vg.from('gaia_viz', { filterBy: $brush }), {
+              x: vg.bin('phot_g_mean_mag'),
+              y: vg.count(),
+              fill: 'steelblue',
+              inset: 0.5,
+            }),
             vg.intervalX({ as: $brush }),
             vg.xDomain(vg.Fixed),
             vg.yScale($scaleType),
@@ -68,10 +74,12 @@ export class GaiaStarCatalogViz implements Viz {
             vg.marginLeft(65)
           ),
           vg.plot(
-            vg.rectY(
-              vg.from("gaia_viz", { filterBy: $brush }),
-              { x: vg.bin("parallax"), y: vg.count(), fill: "steelblue", inset: 0.5 }
-            ),
+            vg.rectY(vg.from('gaia_viz', { filterBy: $brush }), {
+              x: vg.bin('parallax'),
+              y: vg.count(),
+              fill: 'steelblue',
+              inset: 0.5,
+            }),
             vg.intervalX({ as: $brush }),
             vg.xDomain(vg.Fixed),
             vg.yScale($scaleType),
@@ -84,14 +92,18 @@ export class GaiaStarCatalogViz implements Viz {
       ),
       vg.hspace(10),
       vg.plot(
-        vg.raster(
-          vg.from("gaia_viz", { filterBy: $brush }),
-          { x: "bp_rp", y: "phot_g_mean_mag", fill: "density", bandwidth: $bandwidth, binWidth: $binWidth, binType: "normal" }
-        ),
+        vg.raster(vg.from('gaia_viz', { filterBy: $brush }), {
+          x: 'bp_rp',
+          y: 'phot_g_mean_mag',
+          fill: 'density',
+          bandwidth: $bandwidth,
+          binWidth: $binWidth,
+          binType: 'normal',
+        }),
         vg.intervalXY({ pixelSize: 2, as: $brush }),
         vg.xyDomain(vg.Fixed),
         vg.colorScale($scaleType),
-        vg.colorScheme("viridis"),
+        vg.colorScheme('viridis'),
         vg.yReverse(true),
         vg.width(230),
         vg.height(370),

--- a/examples/mosaic-integration/src/vizzes/SeattleWeather.ts
+++ b/examples/mosaic-integration/src/vizzes/SeattleWeather.ts
@@ -9,46 +9,64 @@ import { Viz } from '../Viz';
 export class SeattleWeatherViz implements Viz {
   async initialize() {
     // Materialize the data for the viz into a local temp table.
-    await vg.coordinator().exec(
-      "CREATE TEMP TABLE IF NOT EXISTS weather AS SELECT * FROM mosaic_examples.main.seattle_weather"
-    );
+    await vg
+      .coordinator()
+      .exec(
+        'CREATE TEMP TABLE IF NOT EXISTS weather AS SELECT * FROM mosaic_examples.main.seattle_weather'
+      );
   }
 
   render(): Element {
     const $click = vg.Selection.single();
-    const $domain = vg.Param.array(["sun", "fog", "drizzle", "rain", "snow"]);
-    const $colors = vg.Param.array(["#e7ba52", "#a7a7a7", "#aec7e8", "#1f77b4", "#9467bd"]);
+    const $domain = vg.Param.array(['sun', 'fog', 'drizzle', 'rain', 'snow']);
+    const $colors = vg.Param.array([
+      '#e7ba52',
+      '#a7a7a7',
+      '#aec7e8',
+      '#1f77b4',
+      '#9467bd',
+    ]);
     const $range = vg.Selection.intersect();
 
     return vg.vconcat(
       vg.hconcat(
         vg.plot(
-          vg.dot(
-            vg.from("weather", { filterBy: $click }),
-            { x: vg.dateMonthDay("date"), y: "temp_max", fill: "weather", r: "precipitation", fillOpacity: 0.7 }
-          ),
-          vg.intervalX({ as: $range, brush: {"fill":"none","stroke":"#888"} }),
-          vg.highlight({ by: $range, fill: "#ccc", fillOpacity: 0.2 }),
+          vg.dot(vg.from('weather', { filterBy: $click }), {
+            x: vg.dateMonthDay('date'),
+            y: 'temp_max',
+            fill: 'weather',
+            r: 'precipitation',
+            fillOpacity: 0.7,
+          }),
+          vg.intervalX({
+            as: $range,
+            brush: { 'fill': 'none', 'stroke': '#888' },
+          }),
+          vg.highlight({ by: $range, fill: '#ccc', fillOpacity: 0.2 }),
           vg.colorLegend({ as: $click, columns: 1 }),
           vg.xyDomain(vg.Fixed),
-          vg.xTickFormat("%b"),
+          vg.xTickFormat('%b'),
           vg.colorDomain($domain),
           vg.colorRange($colors),
           vg.rDomain(vg.Fixed),
-          vg.rRange([2,10]),
+          vg.rRange([2, 10]),
           vg.width(680),
           vg.height(300)
         )
       ),
       vg.plot(
-        vg.barX(
-          vg.from("weather"),
-          { x: vg.count(), y: "weather", fill: "#ccc", fillOpacity: 0.2 }
-        ),
-        vg.barX(
-          vg.from("weather", { filterBy: $range }),
-          { x: vg.count(), y: "weather", fill: "weather", order: "weather" }
-        ),
+        vg.barX(vg.from('weather'), {
+          x: vg.count(),
+          y: 'weather',
+          fill: '#ccc',
+          fillOpacity: 0.2,
+        }),
+        vg.barX(vg.from('weather', { filterBy: $range }), {
+          x: vg.count(),
+          y: 'weather',
+          fill: 'weather',
+          order: 'weather',
+        }),
         vg.toggleY({ as: $click }),
         vg.highlight({ by: $click }),
         vg.xDomain(vg.Fixed),


### PR DESCRIPTION
The "prod" build hit a type error with topojson that the "dev" build didn't. I added `@types/topojson-client` and did a little type hacking to appease the compiler.

I also formatted the new viz files (VS Code > Format Document) for consistency with the other code in this example. Mostly this just standardizes quote types.