### PR TITLE
Improve loading time of examples that use temp tables

### DIFF
--- a/examples/mosaic-integration/src/vizzes/Earthquakes.ts
+++ b/examples/mosaic-integration/src/vizzes/Earthquakes.ts
@@ -14,7 +14,7 @@ export class EarthquakeViz implements Viz {
     await vg
       .coordinator()
       .exec(
-        'CREATE TEMP TABLE IF NOT EXISTS earthquakes_viz AS SELECT * FROM mosaic_examples.main.earthquakes'
+        'CREATE TEMP VIEW IF NOT EXISTS earthquakes_viz AS SELECT * FROM mosaic_examples.main.earthquakes'
       );
     this.land = await fetch('/countries-110m.json')
       .then((r) => r.json())

--- a/examples/mosaic-integration/src/vizzes/FlightsViz.ts
+++ b/examples/mosaic-integration/src/vizzes/FlightsViz.ts
@@ -22,14 +22,14 @@ export class FlightsViz implements Viz {
     const rawTable = `mosaic_examples.main.${this.flightsTableName}`;
     if (this.flightsTableName === 'flights_10m') {
       await vg.coordinator().exec(`
-      create temp table if not exists ${flights10MVizTableName} as
+      create temp view if not exists ${flights10MVizTableName} as
       select GREATEST(-60, LEAST(ARR_DELAY, 180))::DOUBLE AS delay, DISTANCE AS distance, DEP_TIME AS time
       from ${rawTable}
       `);
       this.vizTable = flights10MVizTableName;
     } else {
       await vg.coordinator().exec(`
-      create temp table if not exists ${flights200KVizTableName} as
+      create temp view if not exists ${flights200KVizTableName} as
       select *
       from ${rawTable}
       `);

--- a/examples/mosaic-integration/src/vizzes/GaiaStarCatalogViz.ts
+++ b/examples/mosaic-integration/src/vizzes/GaiaStarCatalogViz.ts
@@ -10,7 +10,9 @@ export class GaiaStarCatalogViz implements Viz {
   async initialize() {
     // Materialize the data for the viz into a local temp table.
     await vg.coordinator().exec(
-      `CREATE TEMP TABLE IF NOT EXISTS gaia_viz AS -- compute u and v with natural earth projection
+      `CREATE DATABASE IF NOT EXISTS mosaic_examples_temp;`);
+    await vg.coordinator().exec(
+      `CREATE TABLE IF NOT EXISTS mosaic_examples_temp.gaia_viz AS -- compute u and v with natural earth projection
       WITH prep AS (
         SELECT
           radians((-l + 540) % 360 - 180) AS lambda,
@@ -39,7 +41,7 @@ export class GaiaStarCatalogViz implements Viz {
     return vg.hconcat(
       vg.vconcat(
         vg.plot(
-          vg.raster(vg.from('gaia_viz', { filterBy: $brush }), {
+          vg.raster(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
             x: 'u',
             y: 'v',
             fill: 'density',
@@ -59,7 +61,7 @@ export class GaiaStarCatalogViz implements Viz {
         ),
         vg.hconcat(
           vg.plot(
-            vg.rectY(vg.from('gaia_viz', { filterBy: $brush }), {
+            vg.rectY(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
               x: vg.bin('phot_g_mean_mag'),
               y: vg.count(),
               fill: 'steelblue',
@@ -74,7 +76,7 @@ export class GaiaStarCatalogViz implements Viz {
             vg.marginLeft(65)
           ),
           vg.plot(
-            vg.rectY(vg.from('gaia_viz', { filterBy: $brush }), {
+            vg.rectY(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
               x: vg.bin('parallax'),
               y: vg.count(),
               fill: 'steelblue',
@@ -92,7 +94,7 @@ export class GaiaStarCatalogViz implements Viz {
       ),
       vg.hspace(10),
       vg.plot(
-        vg.raster(vg.from('gaia_viz', { filterBy: $brush }), {
+        vg.raster(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
           x: 'bp_rp',
           y: 'phot_g_mean_mag',
           fill: 'density',

--- a/examples/mosaic-integration/src/vizzes/GaiaStarCatalogViz.ts
+++ b/examples/mosaic-integration/src/vizzes/GaiaStarCatalogViz.ts
@@ -10,9 +10,7 @@ export class GaiaStarCatalogViz implements Viz {
   async initialize() {
     // Materialize the data for the viz into a local temp table.
     await vg.coordinator().exec(
-      `CREATE DATABASE IF NOT EXISTS mosaic_examples_temp;`);
-    await vg.coordinator().exec(
-      `CREATE TABLE IF NOT EXISTS mosaic_examples_temp.gaia_viz AS -- compute u and v with natural earth projection
+      `CREATE TEMP VIEW IF NOT EXISTS gaia_viz AS -- compute u and v with natural earth projection
       WITH prep AS (
         SELECT
           radians((-l + 540) % 360 - 180) AS lambda,
@@ -41,7 +39,7 @@ export class GaiaStarCatalogViz implements Viz {
     return vg.hconcat(
       vg.vconcat(
         vg.plot(
-          vg.raster(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
+          vg.raster(vg.from('gaia_viz', { filterBy: $brush }), {
             x: 'u',
             y: 'v',
             fill: 'density',
@@ -61,7 +59,7 @@ export class GaiaStarCatalogViz implements Viz {
         ),
         vg.hconcat(
           vg.plot(
-            vg.rectY(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
+            vg.rectY(vg.from('gaia_viz', { filterBy: $brush }), {
               x: vg.bin('phot_g_mean_mag'),
               y: vg.count(),
               fill: 'steelblue',
@@ -76,7 +74,7 @@ export class GaiaStarCatalogViz implements Viz {
             vg.marginLeft(65)
           ),
           vg.plot(
-            vg.rectY(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
+            vg.rectY(vg.from('gaia_viz', { filterBy: $brush }), {
               x: vg.bin('parallax'),
               y: vg.count(),
               fill: 'steelblue',
@@ -94,7 +92,7 @@ export class GaiaStarCatalogViz implements Viz {
       ),
       vg.hspace(10),
       vg.plot(
-        vg.raster(vg.from('mosaic_examples_temp.gaia_viz', { filterBy: $brush }), {
+        vg.raster(vg.from('gaia_viz', { filterBy: $brush }), {
           x: 'bp_rp',
           y: 'phot_g_mean_mag',
           fill: 'density',

--- a/examples/mosaic-integration/src/vizzes/MarkTypesViz.ts
+++ b/examples/mosaic-integration/src/vizzes/MarkTypesViz.ts
@@ -25,7 +25,7 @@ export class MarkTypesViz implements Viz {
       await vg
         .coordinator()
         .exec(
-          'create temp table if not exists md as select * from mosaic_examples.main.md'
+          'create temp view if not exists md as select * from mosaic_examples.main.md'
         );
     } else {
       // Create the necessary data in a local temp table from scratch.

--- a/examples/mosaic-integration/src/vizzes/NYPDComplaintsViz.ts
+++ b/examples/mosaic-integration/src/vizzes/NYPDComplaintsViz.ts
@@ -10,7 +10,7 @@ export class NYPDComplaintsViz implements Viz {
   async initialize() {
     // Materialize the data for the viz into a local temp table.
     await vg.coordinator().exec(
-      `create temp table if not exists complaints as 
+      `create temp view if not exists complaints as 
         select year(created_date)::int as Year, count(*)::int as Complaints
         from sample_data.nyc.service_requests
         where Year < 2023
@@ -19,7 +19,7 @@ export class NYPDComplaintsViz implements Viz {
         order by 1;`
     );
     await vg.coordinator().exec(
-      `create temp table if not exists complaints_details as
+      `create temp view if not exists complaints_details as
         select year(created_date)::int as Year, complaint_type as Type, count(*)::int as Complaints
         from sample_data.nyc.service_requests
         where Year < 2023

--- a/examples/mosaic-integration/src/vizzes/SeattleWeather.ts
+++ b/examples/mosaic-integration/src/vizzes/SeattleWeather.ts
@@ -12,7 +12,7 @@ export class SeattleWeatherViz implements Viz {
     await vg
       .coordinator()
       .exec(
-        'CREATE TEMP TABLE IF NOT EXISTS weather AS SELECT * FROM mosaic_examples.main.seattle_weather'
+        'CREATE TEMP VIEW IF NOT EXISTS weather AS SELECT * FROM mosaic_examples.main.seattle_weather'
       );
   }
 


### PR DESCRIPTION
Create temp table remotely instead of locally to reduce the transfer cost. Instead of pulling all of the data from the server and then running a projection locally, run the projections remotely and then download the data. This reduces the amount of data downloaded from 200MB to 40MB and runtime from ~30s to ~6s on a ~350Mbps internet connection.