### PR TITLE
Add a "Get Token" button to both examples, enabling a smoother authentication flow.

### DIFF
--- a/examples/mosaic-integration/src/ConnectPane.css
+++ b/examples/mosaic-integration/src/ConnectPane.css
@@ -8,7 +8,7 @@
   background-color: lightyellow;
   margin: 8px 12px;
   padding: 8px 12px;
-  border-radius: 2px;
+  border-radius: 4px;
   box-shadow: 2px 2px 2px #aaa;
 }
 

--- a/examples/mosaic-integration/src/ConnectPane.css
+++ b/examples/mosaic-integration/src/ConnectPane.css
@@ -3,6 +3,15 @@
   flex-direction: column;
 }
 
+#token-in-clipboard-note {
+  align-self: center;
+  background-color: lightyellow;
+  margin: 8px 12px;
+  padding: 8px 12px;
+  border-radius: 2px;
+  box-shadow: 2px 2px 2px #aaa;
+}
+
 #token-input-row {
   padding: 8px;
   display: flex;
@@ -18,6 +27,14 @@
   padding: 8px;
   display: flex;
   place-content: center;
+}
+
+#connect-button-row > * + * {
+  margin-left: 12px;
+}
+
+#get-token-button {
+  padding: 8px 12px;
 }
 
 #connect-button {

--- a/examples/mosaic-integration/src/ConnectPane.tsx
+++ b/examples/mosaic-integration/src/ConnectPane.tsx
@@ -1,26 +1,77 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import './ConnectPane.css';
+
+const motherDuckUrl = 'https://app.motherduck.com';
+
+const appName = 'WASM Client Library Example: Mosaic Integration';
 
 export function ConnectPane({ connect }: { connect: (token: string) => void }) {
   const [token, setToken] = useState<string | null>(null);
+  const [tokenInClipboard, setTokenInClipboard] = useState<boolean>(false);
 
   const handleTokenInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setToken(e.target.value);
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setToken(event.target.value);
     },
     []
   );
 
+  const handleGetTokenButtonClick = useCallback(() => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('tokenInClipboard', 'y');
+    window.location.href = `${motherDuckUrl}/token-request?appName=${encodeURIComponent(
+      appName
+    )}&returnTo=${encodeURIComponent(url.toString())}`;
+  }, []);
+
   const handleConnectButtonClick = useCallback(() => {
     if (token) {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('tokenInClipboard')) {
+        url.searchParams.delete('tokenInClipboard');
+        history.pushState({}, '', url);
+      }
       connect(token);
     }
   }, [connect, token]);
 
+  useEffect(() => {
+    async function attemptConnect() {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('tokenInClipboard')) {
+        // This only works in Chrome. User has to manually paste in other browsers (Firefox, Safari).
+        if (navigator.clipboard.readText) {
+          const token = await navigator.clipboard.readText();
+          if (token) {
+            url.searchParams.delete('tokenInClipboard');
+            history.pushState({}, '', url);
+            connect(token);
+            return;
+          }
+        }
+        setTokenInClipboard(true);
+      }
+    }
+    attemptConnect();
+  }, [connect]);
+
+  const setTextInputRef = useCallback((element: HTMLInputElement | null) => {
+    if (element) {
+      element.focus();
+    }
+  }, []);
+
   return (
     <div id="connect-pane">
+      <div
+        id="token-in-clipboard-note"
+        style={{ visibility: tokenInClipboard ? 'visible' : 'hidden' }}
+      >
+        Your token is in the clipboard. Paste it and click Connect.
+      </div>
       <div id="token-input-row">
         <input
+          ref={setTextInputRef}
           id="token-input"
           type="password"
           placeholder="Paste MotherDuck Service Token Here"
@@ -28,6 +79,9 @@ export function ConnectPane({ connect }: { connect: (token: string) => void }) {
         />
       </div>
       <div id="connect-button-row">
+        <button id="get-token-button" onClick={handleGetTokenButtonClick}>
+          Get Token
+        </button>
         <button
           id="connect-button"
           disabled={!token}

--- a/examples/nypd-complaints/src/ConnectPane.tsx
+++ b/examples/nypd-complaints/src/ConnectPane.tsx
@@ -1,7 +1,7 @@
-import { MDConnection } from "@motherduck/wasm-client";
-import { Button, TextInput } from "@tremor/react";
-import { useCallback, useEffect, useState } from "react";
-import "./ConnectPane.css";
+import { MDConnection } from '@motherduck/wasm-client';
+import { Button, TextInput } from '@tremor/react';
+import { useCallback, useEffect, useState } from 'react';
+import './ConnectPane.css';
 
 const motherDuckUrl = 'https://app.motherduck.com';
 
@@ -24,7 +24,9 @@ export function ConnectPane({
   const handleGetTokenButtonClick = useCallback(() => {
     const url = new URL(window.location.href);
     url.searchParams.set('tokenInClipboard', 'y');
-    window.location.href = `${motherDuckUrl}/token-request?appName=${encodeURIComponent(appName)}&returnTo=${encodeURIComponent(url.toString())}`;
+    window.location.href = `${motherDuckUrl}/token-request?appName=${encodeURIComponent(
+      appName
+    )}&returnTo=${encodeURIComponent(url.toString())}`;
   }, []);
 
   const handleConnectButtonClick = useCallback(() => {
@@ -82,11 +84,7 @@ export function ConnectPane({
         />
       </div>
       <div id="connect-button-row">
-        <Button
-          onClick={handleGetTokenButtonClick}
-        >
-          Get Token
-        </Button>
+        <Button onClick={handleGetTokenButtonClick}>Get Token</Button>
         <Button
           disabled={!(!connection && token)}
           onClick={handleConnectButtonClick}

--- a/examples/nypd-complaints/src/ConnectPane.tsx
+++ b/examples/nypd-complaints/src/ConnectPane.tsx
@@ -16,6 +16,7 @@ export function ConnectPane({
   connect: (token: string) => void;
 }) {
   const [token, setToken] = useState<string | null>(null);
+  const [tokenInClipboard, setTokenInClipboard] = useState<boolean>(false);
 
   const handleTokenInputChange = useCallback((value: string) => {
     setToken(value);
@@ -23,12 +24,17 @@ export function ConnectPane({
 
   const handleGetTokenButtonClick = useCallback(() => {
     const url = new URL(window.location.href);
-    url.searchParams.set('paste', 'y');
+    url.searchParams.set('tokenInClipboard', 'y');
     window.location.href = `${motherDuckUrl}/token-request?appName=${encodeURIComponent(appName)}&returnTo=${encodeURIComponent(url.toString())}`;
   }, []);
 
   const handleConnectButtonClick = useCallback(() => {
     if (token) {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('tokenInClipboard')) {
+        url.searchParams.delete('tokenInClipboard');
+        history.pushState({}, '', url);
+      }
       connect(token);
     }
   }, [connect, token]);
@@ -36,23 +42,40 @@ export function ConnectPane({
   useEffect(() => {
     async function attemptConnect() {
       const url = new URL(window.location.href);
-      if (url.searchParams.get('paste')) {
-        url.searchParams.delete('paste');
-        history.pushState({}, '', url);
+      if (url.searchParams.get('tokenInClipboard')) {
         // This only works in Chrome. User has to manually paste in other browsers (Firefox, Safari).
-        const token = await navigator.clipboard.readText();
-        if (token) {
-          connect(token);
+        if (navigator.clipboard.readText) {
+          const token = await navigator.clipboard.readText();
+          if (token) {
+            url.searchParams.delete('tokenInClipboard');
+            history.pushState({}, '', url);
+            connect(token);
+            return;
+          }
         }
+        setTokenInClipboard(true);
       }
     }
     attemptConnect();
   }, [connect]);
 
+  const setTextInputRef = useCallback((element: HTMLInputElement | null) => {
+    if (element) {
+      element.focus();
+    }
+  }, []);
+
   return (
     <div id="connect-pane" className="pt-32">
+      <div
+        className="bg-blue-100 text-blue-800 text-sm font-medium px-2.5 py-0.5 rounded dark:bg-blue-900 dark:text-blue-300"
+        style={{ visibility: tokenInClipboard ? 'visible' : 'hidden' }}
+      >
+        Your token is in the clipboard. Paste it and click Connect.
+      </div>
       <div id="token-input-row">
         <TextInput
+          ref={setTextInputRef}
           type="password"
           autoComplete="off"
           placeholder="Paste MotherDuck Service Token Here"

--- a/examples/nypd-complaints/src/ConnectPane.tsx
+++ b/examples/nypd-complaints/src/ConnectPane.tsx
@@ -3,8 +3,7 @@ import { Button, TextInput } from "@tremor/react";
 import { useCallback, useEffect, useState } from "react";
 import "./ConnectPane.css";
 
-// TODO: use https://app.motherduck.com
-const motherDuckUrl = 'http://localhost:8080';
+const motherDuckUrl = 'https://app.motherduck.com';
 
 const appName = 'WASM Client Library Example: NYPD Complaints';
 


### PR DESCRIPTION
To make it easier to authenticate an application based on the MD WASM Client library, we recently introduced a `/token-request` page to https://app.motherduck.com that makes it easier to provide a token to a requesting application. This change integrates use of this new flow into both examples.