### PR TITLE
Add FourSquareViz and NYCRidesViz

### DIFF
--- a/examples/mosaic-integration/src/VizzesPane.tsx
+++ b/examples/mosaic-integration/src/VizzesPane.tsx
@@ -3,6 +3,8 @@ import { Viz } from './Viz';
 import './VizzesPane.css';
 import { MarkTypesViz, NYPDComplaintsViz, GaiaStarCatalogViz, EarthquakeViz, SeattleWeatherViz } from './vizzes';
 import { FlightsViz } from './vizzes/FlightsViz';
+import { FourSquareViz } from './vizzes/FourSquareViz';
+import { NYCRidesViz } from './vizzes/NYCRides';
 
 const vizMap: Record<string, Viz> = {
   'Mark Types': new MarkTypesViz(),
@@ -12,6 +14,8 @@ const vizMap: Record<string, Viz> = {
   'Flights 200K': new FlightsViz('flights_200k'),
   'Flights 10M': new FlightsViz('flights_10m'),
   'Gaia Star Catalog': new GaiaStarCatalogViz(),
+  'NYC Rides': new NYCRidesViz(),
+  'Foursquare Places': new FourSquareViz(),
 };
 const vizNames = Object.keys(vizMap);
 

--- a/examples/mosaic-integration/src/vizzes/FourSquareViz.ts
+++ b/examples/mosaic-integration/src/vizzes/FourSquareViz.ts
@@ -1,0 +1,141 @@
+import * as vg from '@uwdata/vgplot';
+import { Viz } from '../Viz';
+
+export class FourSquareViz implements Viz {
+  async initialize() {
+    await vg.coordinator().exec(`INSTALL spatial`);
+    await vg.coordinator().exec(`LOAD spatial`);
+    await vg.coordinator().exec(`
+    CREATE TABLE IF NOT EXISTS fsq_places_by_year_nyc AS
+      WITH dates_location AS
+        (
+          SELECT
+            date_created::TIMESTAMP AS date_created,
+            date_closed::TIMESTAMP AS date_closed,
+            ST_Transform(ST_Point(latitude, longitude), 'EPSG:4326', 'ESRI:102718') AS location,
+            list_any_value(fsq_category_labels) as label
+            FROM foursquare_places
+            WHERE locality='New York'
+        )
+        SELECT
+          YEAR(date_created) AS created,
+          YEAR(date_closed) AS closed,
+          ST_X(location) AS x,
+          ST_Y(location) AS y,
+          label,
+          level1_category_name,
+          level2_category_name
+        FROM dates_location dl
+        JOIN foursquare_categories cat
+        ON dl.label = cat.category_label
+    `);
+    await vg.coordinator().exec(`
+    CREATE TEMP TABLE IF NOT EXISTS fsq_places AS
+      SELECT * FROM fsq_places_by_year_nyc
+      WHERE
+        x > 900000
+        AND x < 1100000
+        AND y > 100000
+        AND y < 400000
+    `);
+  }
+
+  render(): Element {
+    const $range = vg.Selection.crossfilter();
+    const $domain = vg.Param.array([
+      "Arts and Entertainment",
+      "Business and Professional Services",
+      "Community and Government",
+      "Dining and Drinking",
+      "Event",
+      "Health and Medicine",
+      "Landmarks and Outdoors",
+      "Retail",
+      "Sports and Recreation",
+      "Travel and Transportation",
+    ]);
+    // const $highlight = vg.Selection.intersect();
+
+    return vg.vconcat(
+      vg.hconcat(
+        vg.plot(
+          vg.raster(
+            vg.from("fsq_places", { filterBy: $range }),
+            { x: "x", y: "y", bandwidth: 0 }
+          ),
+          vg.text(
+            [{ label: "Places of interest in NYC" }],
+            {
+              dx: 10,
+              dy: 10,
+              text: "label",
+              fill: "black",
+              fontSize: "1.2em",
+              frameAnchor: "top-left"
+            }
+          ),
+          // vg.intervalXY({as: $range}),
+          vg.width(335),
+          vg.height(550),
+          vg.margin(0),
+          vg.xAxis(null),
+          vg.yAxis(null),
+          vg.xDomain([975000, 1005000]),
+          vg.yDomain([190000, 240000]),
+          vg.colorScale("symlog"),
+          vg.colorScheme("blues")
+        ),
+        vg.vspace(10),
+        vg.plot(
+          vg.barX(
+            vg.from("fsq_places", {filterBy: $range}),
+            {
+              x: vg.count(),
+              y: "level1_category_name",
+              fill: "level1_category_name",
+            }
+          ),
+          // vg.toggleY({as: $range}),
+          // vg.toggleY({as: $highlight}),
+          // vg.highlight({by: $highlight}),
+          vg.colorDomain(vg.Fixed),
+          vg.yLabel("Level 1 category"),
+          vg.xTickFormat("s"),
+          vg.xLabel("count"),
+          vg.yDomain($domain),
+          vg.colorDomain($domain),
+          vg.width(680),
+          vg.height(550),
+          vg.marginTop(5),
+          vg.marginLeft(220),
+          vg.marginBottom(35)
+        )
+      ),
+      vg.hspace(10),
+      vg.plot(
+        vg.rectY(
+          vg.from("fsq_places"),
+          { x: vg.bin("created"), y: vg.count(), fill: "steelblue", inset: 0.5 }
+        ),
+        vg.intervalX({ as: $range }),
+        vg.yTickFormat("s"),
+        vg.xLabel("Year created →"),
+        vg.width(680),
+        vg.height(100)
+      ),
+      vg.hspace(10),
+      vg.plot(
+        vg.rectY(
+          vg.from("fsq_places"),
+          { x: vg.bin("closed"), y: vg.count(), fill: "steelblue", inset: 0.5 }
+        ),
+        vg.yDomain([0, 10000]),
+        vg.intervalX({ as: $range }),
+        vg.yTickFormat("s"),
+        vg.xLabel("Year closed →"),
+        vg.width(680),
+        vg.height(100)
+      )
+    );
+  }
+}

--- a/examples/mosaic-integration/src/vizzes/NYCRides.ts
+++ b/examples/mosaic-integration/src/vizzes/NYCRides.ts
@@ -1,0 +1,100 @@
+import * as vg from '@uwdata/vgplot';
+import { Viz } from '../Viz';
+
+export class NYCRidesViz implements Viz {
+  async initialize() {
+    await vg.coordinator().exec(`INSTALL spatial`);
+    await vg.coordinator().exec(`LOAD spatial`);
+    await vg.coordinator().exec(
+      `CREATE TABLE IF NOT EXISTS trips AS
+        WITH rides AS (
+          SELECT
+            pickup_datetime::TIMESTAMP AS datetime,
+            ST_Transform(ST_Point(pickup_latitude, pickup_longitude), 'EPSG:4326', 'ESRI:102718') AS pick,
+            ST_Transform(ST_Point(dropoff_latitude, dropoff_longitude), 'EPSG:4326', 'ESRI:102718') AS drop
+            from 'https://idl.uw.edu/mosaic-datasets/data/nyc-rides-2010.parquet'
+        )
+        SELECT
+          (HOUR(datetime) + MINUTE(datetime)/60) AS time,
+          ST_X(pick) AS px, ST_Y(pick) AS py,
+          ST_X(drop) AS dx, ST_Y(drop) AS dy
+        FROM rides`
+    );
+  }
+
+  render(): Element {
+    const $filter = vg.Selection.crossfilter();
+
+    return vg.vconcat(
+      vg.hconcat(
+        vg.plot(
+          vg.raster(
+            vg.from("trips", { filterBy: $filter }),
+            { x: "px", y: "py", bandwidth: 0 }
+          ),
+          vg.intervalXY({ as: $filter }),
+          vg.text(
+            [{ label: "Taxi Pickups" }],
+            {
+              dx: 10,
+              dy: 10,
+              text: "label",
+              fill: "black",
+              fontSize: "1.2em",
+              frameAnchor: "top-left"
+            }
+          ),
+          vg.width(335),
+          vg.height(550),
+          vg.margin(0),
+          vg.xAxis(null),
+          vg.yAxis(null),
+          vg.xDomain([975000, 1005000]),
+          vg.yDomain([190000, 240000]),
+          vg.colorScale("symlog"),
+          vg.colorScheme("blues")
+        ),
+        vg.hspace(10),
+        vg.plot(
+          vg.raster(
+            vg.from("trips", { filterBy: $filter }),
+            { x: "dx", y: "dy", bandwidth: 0 }
+          ),
+          vg.intervalXY({ as: $filter }),
+          vg.text(
+            [{ label: "Taxi Dropoffs" }],
+            {
+              dx: 10,
+              dy: 10,
+              text: "label",
+              fill: "black",
+              fontSize: "1.2em",
+              frameAnchor: "top-left"
+            }
+          ),
+          vg.width(335),
+          vg.height(550),
+          vg.margin(0),
+          vg.xAxis(null),
+          vg.yAxis(null),
+          vg.xDomain([975000, 1005000]),
+          vg.yDomain([190000, 240000]),
+          vg.colorScale("symlog"),
+          vg.colorScheme("oranges")
+        )
+      ),
+      vg.vspace(10),
+      vg.plot(
+        vg.rectY(
+          vg.from("trips"),
+          { x: vg.bin("time"), y: vg.count(), fill: "steelblue", inset: 0.5 }
+        ),
+        vg.intervalX({ as: $filter }),
+        vg.yTickFormat("s"),
+        vg.xLabel("Pickup Hour →"),
+        vg.width(680),
+        vg.height(100)
+      )
+    );
+  }
+}


### PR DESCRIPTION
Demo using the Foursquare places data ([link](https://docs.foursquare.com/data-products/docs/access-fsq-os-places)):
![MotherDuckWASMClientExample_MosaicIntegration-29November20243-ezgif com-video-to-gif-converter (2)](https://github.com/user-attachments/assets/3ca9691e-1b7c-4140-90f0-c202a4a517ac)

Demo based on the NYC Taxi rides data from the Mosaic gallery ([link](https://idl.uw.edu/mosaic/examples/nyc-taxi-rides.html)):
![MotherDuckWASMClientExample_MosaicIntegration-29November20241-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ef68a0b2-4bbe-412e-a772-54ca68c751ba)